### PR TITLE
Show relationships broke due to parent key being invalid

### DIFF
--- a/lib/jsonapi/request.rb
+++ b/lib/jsonapi/request.rb
@@ -82,7 +82,7 @@ module JSONAPI
     end
 
     def setup_show_relationship_action(params)
-      add_show_relationship_operation(params[:relationship], params.require(@resource_klass._as_parent_key))
+      add_show_relationship_operation(params[:relationship], params.require(@resource_klass._as_parent_key_id))
     end
 
     def setup_create_action(params)


### PR DESCRIPTION
The parent key returns the wrong column. We translate guid's to id and
back id's to guids. When accessing using the self link this call fails
due to our overriding _as_parent_key to reference object_guid for most
calls this is what we want but on show relationship the call is coming
from URL parameters object_id and the show relationship params are
looking of object_id instead of object_guid.  We have two function one
for parent_key_id and the other for parent_key the parent_key has been
overridden to include object_guid.
